### PR TITLE
Update payload_hash.sh

### DIFF
--- a/scripts/payload_hash.sh
+++ b/scripts/payload_hash.sh
@@ -6,7 +6,7 @@ eval "$(jq -r '@sh "FILENAME=\(.filename)"')"
 
 if ! [ -f ${FILENAME} ]; then
   /usr/local/bin/jq -n --arg sha "" --arg md5 "" '{"sha":$sha, "md5": $md5}'
-  echo "ERROR: No payload zip!" >&2
+  echo "ERROR: No payload zip at ${FILENAME}!" >&2
   exit 1
 fi
 

--- a/scripts/payload_hash.sh
+++ b/scripts/payload_hash.sh
@@ -6,8 +6,8 @@ eval "$(jq -r '@sh "FILENAME=\(.filename)"')"
 
 if ! [ -f ${FILENAME} ]; then
   /usr/local/bin/jq -n --arg sha "" --arg md5 "" '{"sha":$sha, "md5": $md5}'
+  echo "ERROR: No payload zip!" >&2
   exit 1
-  >&2 echo "ERROR: No payload zip!"
 fi
 
 sha=$(openssl dgst -sha256 -binary ${FILENAME} | openssl enc -base64)


### PR DESCRIPTION
Make sure error message is written out when payload is not present.

Currently, the exit call stops the echo line from executing.