### PR TITLE
Add explicit dependency for SHA generation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,8 @@ resource "null_resource" "cleanup_project_work_directory" {
 data "external" "payload_sha" {
   program = ["bash", "${path.module}/scripts/payload_hash.sh"]
 
+  depends_on = ["null_resource.build_payload"]
+
   query = {
     filename = "${var.output_path}/${var.name}_${data.external.payload_exists.result["identifier"]}_payload.zip"
     id       = "${null_resource.build_payload.id}"


### PR DESCRIPTION
I'm not sure why I didn't see this earlier, other than luck. But I had to add an explicit dependency to payload hash generation on the payload build completing.