### PR TITLE
Include the path in the hash to avoid time collisions

### DIFF
--- a/scripts/payload_exists.py
+++ b/scripts/payload_exists.py
@@ -4,6 +4,7 @@ import re
 import json
 import glob, os
 import datetime
+import hashlib
 
 var = json.loads(sys.stdin.read())
 # We expect there to be:
@@ -18,8 +19,12 @@ files = glob.glob(path)
 
 if not files:
     # okay we have no files
-    # We generate a new indicator and return that
-    identifier = int(datetime.datetime.now().strftime("%s"))
+    # We generate a new indicator and return that. Include the path in the
+    # hash, so that if we have multiple instances of the module with empty
+    # directories, we avoid clashes on the identifier by calling the script
+    # in quick succession.
+    identifier = int(datetime.datetime.now().strftime("%s")) +\
+        (int(hashlib.md5(path.encode()).hexdigest(), 16) % (10 ** 10))
     sys.stdout.write(json.dumps({"identifier": str(identifier)}, indent=2))
     sys.exit(0)
 


### PR DESCRIPTION
If multiple modules are used, and the payloads are all empty, the generate identifier can be the same across all of them. This occurs when the script is invoked in the same second. This change adds a 10 digit hash of the path, converted to an integer, to the time identifier. 