### PR TITLE
Include filename in hash

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ data "external" "payload_exists" {
 }
 
 # This will create a new work directory only if the requirements
-# has changed
+# or the variable name has changed
 resource "null_resource" "make_virtualenv_work_dir" {
   triggers {
     requirements = "${data.external.requirements_sha.result["sha"]}"

--- a/scripts/requirements_sha.sh
+++ b/scripts/requirements_sha.sh
@@ -4,8 +4,7 @@ set -e
 eval "$(jq -r '@sh "NAME=\(.name) REQUIREMENTS_FILE=\(.requirements_file)"')"
 
 if [ "$REQUIREMENTS_FILE" != "null" ]; then
-  current_requirements_sha=$(shasum -a 256 "${REQUIREMENTS_FILE}" | cut -d " " -f 1)
-  
+  current_requirements_sha=$(echo "$NAME" | cat - "${REQUIREMENTS_FILE}" | shasum -a 256 | cut -d " " -f 1)
 else
   current_requirements_sha=$(echo "$NAME" | shasum -a 256 - | cut -d " " -f 1)
   # >&2 echo "$current_requirements_sha"


### PR DESCRIPTION
If multiple modules are used, and they have the same requirements file, the hash is the same. This hash is used for the temporary directory name for the virtual environment, so it must be unique. This change includes the `name` variable in the hash, which is sufficient to avoid the collision.