### PR TITLE
Use `command` to invoke executable so that we bypass the shell

### DIFF
--- a/scripts/build_virtualenv.sh
+++ b/scripts/build_virtualenv.sh
@@ -35,8 +35,11 @@ fi
 # This should make it easier to control whether or not we're doing
 # something reasonable here.
 
-PYENV="/usr/local/bin/pyenv"
-VIRTUALENV="/usr/local/bin/pyenv-virtualenv"
+# This assumes that the user has the proper path set to the pyenv
+# executable, but does not require `eval "$(penv init -)"` to have been
+# run. If it has, however, this will still work by ensuring we run the
+# executable, not the shell function.
+PYENV="command pyenv"
 
 # eval "$(pyenv init -)"
 MAJOR_VERSION=$(echo $PYTHON_RUNTIME | sed 's/python//')


### PR DESCRIPTION
@aurynn thanks again for this useful module!

I ran into a problem with installation paths with the latest version. The path was hardcoded, and I was having trouble getting pyenv to install in /usr/local/bin properly for some reason. I think the spirit of your change was to bypass the shell function, so I made this modification to do so by invoking it as "command pyenv", which should accomplish the same thing without assuming the path.

