### PR TITLE
Remove absolute path references to jq and zip

### DIFF
--- a/scripts/build_payload.sh
+++ b/scripts/build_payload.sh
@@ -52,7 +52,7 @@ ${BIN}/python -m compileall . > /dev/null 2>&1
 
 # Exclude all the default python stuff that's unnecessary in the default context
 
-/usr/bin/zip -r -q virtualenv.zip . -x "pip*" -x "setuptools*" -x "wheel*" -x easy_install.py -x "__pycache__/easy_install*" -x "*.dist-info*" -x "boto3*" -x "botocore*"
+zip -r -q virtualenv.zip . -x "pip*" -x "setuptools*" -x "wheel*" -x easy_install.py -x "__pycache__/easy_install*" -x "*.dist-info*" -x "boto3*" -x "botocore*"
 
 # zip -r -q virtualenv.zip .
 
@@ -88,7 +88,7 @@ cp $SITE_PACKAGES/virtualenv.zip .
 
 # Build the zipfile, exclude git stuff, and exclude the requirements.txt, if it exists
 echo "building payload zip"
-/usr/bin/zip -q -r virtualenv.zip ./* -x .git -x requirements.txt
+zip -q -r virtualenv.zip ./* -x .git -x requirements.txt
 
 # Output path is expected to be a fully qualified filename
 mv virtualenv.zip ${OUTPUT_PATH}/${FILENAME}

--- a/scripts/payload_hash.sh
+++ b/scripts/payload_hash.sh
@@ -5,7 +5,7 @@ set -e
 eval "$(jq -r '@sh "FILENAME=\(.filename)"')"
 
 if ! [ -f ${FILENAME} ]; then
-  /usr/local/bin/jq -n --arg sha "" --arg md5 "" '{"sha":$sha, "md5": $md5}'
+  jq -n --arg sha "" --arg md5 "" '{"sha":$sha, "md5": $md5}'
   echo "ERROR: No payload zip at ${FILENAME}!" >&2
   exit 1
 fi
@@ -18,4 +18,4 @@ else
   md5=($(md5sum ${FILENAME}))
 fi
 
-/usr/local/bin/jq -n --arg sha "$sha" --arg md5 "$md5" '{"sha":$sha, "md5": $md5}'
+jq -n --arg sha "$sha" --arg md5 "$md5" '{"sha":$sha, "md5": $md5}'


### PR DESCRIPTION
@aurynn I submitted these all as separate PRs so you can pick and choose if you would like to include any.

I noticed that a prior change added the absolute path for `jq` and `zip`. If that was intentional, feel free to ignore. I can probably get by by adding a soft link for `jq` (on ubuntu, it is installed in /usr/bin, not /usr/local/bin, by default). `zip` is installed in /usr/bin, so that one isn't as important.

I thought I'd point out that there is one use of `jq` that was not changed in the prior commit to use an absolute path.