### PR TITLE
Remove redundant popd

### DIFF
--- a/scripts/nodejs/build_payload.sh
+++ b/scripts/nodejs/build_payload.sh
@@ -30,5 +30,3 @@ zip -q -r payload.zip .
 popd
 
 mv $WORK_DIR/payload.zip ${OUTPUT_PATH}/${FILENAME}
-
-popd


### PR DESCRIPTION
The popd running when there is no directory in the pushd stack makes the script error. Removing it resolves the deploy issues