### PR TITLE
Throw if the python runtime version not installed

### DIFF
--- a/scripts/python/build_environment.sh
+++ b/scripts/python/build_environment.sh
@@ -55,6 +55,12 @@ for version in $VERSIONS; do
   break
 done
 
+if ! [ -d $VERSION ]; then
+  echo "ERROR: Python version not found, is it installed in pyenv?"
+  echo "ERROR: Expected: $MAJOR_VERSION"
+  exit 1
+fi
+
 echo "INFO: using python version $VERSION"
 # Versions should be an array now
 


### PR DESCRIPTION
Prior to this if you had python 3.7 installed and was using a python3.6 runtime it would return no versions and explode. This should allow the user to be informed as to why it's not working for them (and prompt to install that required version with pyenv).